### PR TITLE
Add support for pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=pypy
+    - TOXENV=pypy3
 install: pip install tox
 script: tox

--- a/ext/_murmur3.c
+++ b/ext/_murmur3.c
@@ -3,6 +3,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef PYPY_VERSION
+#define COMPILING_IN_PYPY 1
+#define COMPILING_IN_CPYTHON 0
+#else
+#define COMPILING_IN_PYPY 0
+#define COMPILING_IN_CPYTHON 1
+#endif
 // MurmurHash3 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.
 
@@ -72,7 +79,7 @@ struct module_state {
     PyObject *error;
 };
 
-#if PY_MAJOR_VERSION >= 3
+#if COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3
 #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 #else
 #define GETSTATE(m) (&_state)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy
+envlist = py26,py27,py32,py33,py34,pypy,pypy3
 
 [testenv]
 setenv =


### PR DESCRIPTION
PyModule_GetState isn't available in pypy3 yet, fall back to the python2 stuff when in it
